### PR TITLE
Added token report and calculation, updated .toml files, change cli references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,21 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -223,6 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fancy-regex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +310,12 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -618,6 +655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,36 +797,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "toonify-cli"
-version = "0.1.0"
+name = "tiktoken-rs"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c314e7ce51440f9e8f5a497394682a57b7c323d0f4d0a6b1b13c429056e0e234"
 dependencies = [
  "anyhow",
- "assert_cmd",
- "clap",
- "predicates",
- "serde_json",
- "toonify-core",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "parking_lot",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "toonify-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bigdecimal",
  "csv",
  "indexmap",
+ "once_cell",
  "quick-xml",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "tiktoken-rs",
  "unicode-segmentation",
  "xmltree",
 ]
 
 [[package]]
 name = "toonify-node"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -794,9 +842,21 @@ dependencies = [
 
 [[package]]
 name = "toonify-python"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "pyo3",
+ "serde_json",
+ "toonify-core",
+]
+
+[[package]]
+name = "toonifytool-cli"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "predicates",
  "serde_json",
  "toonify-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 members = [
   "crates/toonify-core",
-  "crates/toonify-cli",
+  "crates/toonifytool-cli",
   "bindings/node",
   "bindings/python"
 ]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
-authors = ["Toonify Contributors"]
+authors = ["Andrea Iannoli"]
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -19,3 +19,5 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = "2.2"
+once_cell = "1.19"
+tiktoken-rs = "0.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 FROM rust:1.82-slim AS builder
 WORKDIR /app
 COPY . .
-RUN cargo build --release -p toonify-cli
+RUN cargo build --release -p toonifytool-cli
 
 # Runtime stage
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app/target/release/toonify-cli /usr/local/bin/toonify
+COPY --from=builder /app/target/release/toonify /usr/local/bin/toonify
 ENTRYPOINT ["toonify"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Universal converter for JSON, YAML, XML, and CSV into the [TOON](https://github.
 
 - **Rust core library** (`toonify-core`) that normalizes the supported formats into TOON while following the spec’s quoting, delimiter, and key-folding rules.
 - **First-class decoder/validator** APIs (`decode_str`, `validate_str`) that round-trip TOON into JSON and enforce strict-mode semantics (array counts, indentation, path-expansion conflicts, etc.).
-- **CLI** (`toonify-cli`) for one-shot conversions, TOON → JSON decoding, or standalone validation.
+- **CLI** ([`toonifytool-cli`](https://crates.io/crates/toonifytool-cli)) for one-shot conversions, TOON → JSON decoding, or standalone validation; add `--token-report` for opt-in savings stats.
 - **Node.js bindings** (`bindings/node`, powered by `napi-rs`) that expose encode/decode/validate helpers to JavaScript/TypeScript.
 - **Python bindings** (`bindings/python`, powered by PyO3 + maturin) with the same surface area.
 - **Docker image** for CI/automation scenarios where you just want a containerized CLI.
@@ -42,46 +42,51 @@ TOON decoding/validation options mirror the spec:
 | `loose` / `strict` | Disable (`loose`) or enable (`strict`, default) array count and indentation validation |
 | `pretty` | When decoding, pretty-print JSON output |
 
+### Distribution 🧾
+
+- 📦 crates.io: [`toonifytool-cli`](https://crates.io/crates/toonifytool-cli)
+- 🐳 Docker Hub: [`andreaiannoli/toonify`](https://hub.docker.com/r/andreaiannoli/toonify)
+
 ## Install the CLI globally 🧰
 
-You can make the `toonify-cli` binary available on your `PATH` without referencing `target/release`:
+You can make the `toonify` binary available on your `PATH` without referencing `target/release`:
 
 ```bash
 # build and install the local workspace binary
-cargo install --locked --path crates/toonify-cli
-
-# once published on crates.io you can also do:
-# cargo install --locked toonify-cli
+cargo install --locked toonifytool-cli
 ```
 
-`cargo install` drops binaries into `~/.cargo/bin`, so make sure that directory is on your `PATH`. Afterwards you can run commands such as `toonify-cli --input data.json --format json` from anywhere.
+`cargo install` drops binaries into `~/.cargo/bin`, so make sure that directory is on your `PATH`. Afterwards you can run commands such as `toonify --input data.json --format json` from anywhere.
 
 ## Getting Started ⚙️
 
 ```bash
 # Build the CLI (requires Rust 1.76+)
-cargo build --release -p toonify-cli
+cargo build --release -p toonifytool-cli
 
 # Convert a JSON file
-./target/release/toonify-cli --input fixtures/data.json --format json --key-folding safe
+./target/release/toonify --input fixtures/data.json --format json --key-folding safe
 ```
 
 ### CLI Quick Reference 💡
 
 ```
-toonify-cli --input users.yaml --format yaml --delimiter tab --key-folding safe --flatten-depth 3
+toonify --input users.yaml --format yaml --delimiter tab --key-folding safe --flatten-depth 3
 
 # STDIN → STDOUT
-curl https://example.com/users.csv | toonify-cli --format csv
+curl https://example.com/users.csv | toonify --format csv
 
 # Decode TOON → JSON
-toonify-cli --mode decode --input users.toon --pretty-json
+toonify --mode decode --input users.toon --pretty-json
 
 # Validate a TOON document (strict-mode by default)
-toonify-cli --mode validate --input users.toon
+toonify --mode validate --input users.toon
+
+# Compare token models for savings (default cl100k_base)
+toonify --input users.yaml --format yaml --token-model o200k
 ```
 
-Run `toonify-cli --help` to view every flag.
+Run `toonify --help` to view every flag. When you include `--token-report`, the CLI prints a token report using the selected model (default `cl100k_base`, switch via `--token-model o200k` when targeting GPT-4o-style models).
 
 ### Node.js Package 🧩
 
@@ -149,6 +154,6 @@ Set `ENTRYPOINT` to `toonify`, so passing CLI flags works naturally.
 ## Roadmap / Ideas 💭
 
 - Expand the decoder to support more formats (CSV, YAML, etc.)
-- Add a token saving estimation mechanism
+- Add additional token saving estimation mechanisms (custom tokenizers, streaming mode)
 
 Contributions are welcome—feel free to open issues or PRs with improvements!

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "toonify-node"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
-authors = ["Toonify Contributors"]
+authors = ["Andrea Iannoli"]
 description = "Node.js bindings for the TOON converter"
 license = "MIT"
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "toonify-python"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
-authors = ["Toonify Contributors"]
+authors = ["Andrea Iannoli"]
 description = "Python bindings for the TOON converter"
 license = "MIT"
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,10 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use pyo3::{exceptions::PyValueError, prelude::*};
 use serde_json;
 use toonify_core::{
-    convert_str, decode_str, validate_str, DecoderOptions, Delimiter, EncoderOptions,
-    KeyFoldingMode, PathExpansionMode, SourceFormat,
+    DecoderOptions, Delimiter, EncoderOptions, KeyFoldingMode, PathExpansionMode, SourceFormat,
+    convert_str, decode_str, validate_str,
 };
 
 #[pyfunction]

--- a/crates/toonify-core/Cargo.toml
+++ b/crates/toonify-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "toonify-core"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
-authors = ["Toonify Contributors"]
+authors = ["Andrea Iannoli"]
 description = "Core library for converting structured data formats into the TOON serialization"
 license = "MIT"
 
@@ -19,5 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"
 thiserror = "1.0"
+once_cell = "1.19"
+tiktoken-rs = "0.5"
 unicode-segmentation = "1.11"
 xmltree = "0.10"

--- a/crates/toonify-core/src/error.rs
+++ b/crates/toonify-core/src/error.rs
@@ -24,6 +24,8 @@ pub enum ToonifyError {
     Encoding(String),
     #[error("{0}")]
     Decoding(String),
+    #[error("tokenization error: {0}")]
+    Tokenizer(String),
 }
 
 impl ToonifyError {
@@ -43,5 +45,9 @@ impl ToonifyError {
 
     pub(crate) fn decoding(msg: impl fmt::Display) -> Self {
         Self::Decoding(msg.to_string())
+    }
+
+    pub(crate) fn tokenizer(msg: impl fmt::Display) -> Self {
+        Self::Tokenizer(msg.to_string())
     }
 }

--- a/crates/toonify-core/src/lib.rs
+++ b/crates/toonify-core/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 mod input;
 mod options;
 mod quoting;
+mod tokens;
 mod validator;
 
 pub use crate::decoder::{decode_reader, decode_str};
@@ -13,6 +14,7 @@ pub use crate::input::{load_from_reader, load_from_str, SourceFormat};
 pub use crate::options::{
     DecoderOptions, Delimiter, EncoderOptions, KeyFoldingMode, PathExpansionMode,
 };
+pub use crate::tokens::{count_tokens, TokenModel};
 pub use crate::validator::{validate_reader, validate_str};
 
 /// Convert the provided string in the given `SourceFormat` into TOON.

--- a/crates/toonify-core/src/tokens.rs
+++ b/crates/toonify-core/src/tokens.rs
@@ -1,0 +1,52 @@
+use once_cell::sync::OnceCell;
+use tiktoken_rs::{CoreBPE, cl100k_base, o200k_base};
+
+use crate::error::ToonifyError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TokenModel {
+    Cl100k,
+    O200k,
+}
+
+impl std::fmt::Display for TokenModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenModel::Cl100k => write!(f, "cl100k_base"),
+            TokenModel::O200k => write!(f, "o200k_base"),
+        }
+    }
+}
+
+static CL100K: OnceCell<CoreBPE> = OnceCell::new();
+static O200K: OnceCell<CoreBPE> = OnceCell::new();
+
+pub fn count_tokens(text: &str, model: TokenModel) -> Result<usize, ToonifyError> {
+    let tokenizer = get_tokenizer(model)?;
+    Ok(tokenizer.encode_ordinary(text).len())
+}
+
+fn get_tokenizer(model: TokenModel) -> Result<&'static CoreBPE, ToonifyError> {
+    match model {
+        TokenModel::Cl100k => CL100K.get_or_try_init(|| {
+            cl100k_base().map_err(|err| ToonifyError::tokenizer(err.to_string()))
+        }),
+        TokenModel::O200k => O200K.get_or_try_init(|| {
+            o200k_base().map_err(|err| ToonifyError::tokenizer(err.to_string()))
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_tokens_for_simple_text() {
+        let text = "Hello world!";
+        let cl = count_tokens(text, TokenModel::Cl100k).unwrap();
+        let o2 = count_tokens(text, TokenModel::O200k).unwrap();
+        assert!(cl > 0);
+        assert!(o2 > 0);
+    }
+}

--- a/crates/toonifytool-cli/Cargo.toml
+++ b/crates/toonifytool-cli/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
-name = "toonify-cli"
-version = "0.1.0"
+name = "toonifytool-cli"
+version = "1.0.0"
 edition = "2021"
-authors = ["Toonify Contributors"]
+authors = ["Andrea Iannoli"]
 description = "Command line interface for TOON conversions"
 license = "MIT"
+
+[[bin]]
+name = "toonify"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }
 serde_json = { workspace = true }
-toonify-core = { path = "../toonify-core" }
+toonify-core = { path = "../toonify-core", version = "1.0.0" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/toonifytool-cli/tests/cli.rs
+++ b/crates/toonifytool-cli/tests/cli.rs
@@ -8,7 +8,7 @@ fn fixtures_root() -> PathBuf {
 }
 
 fn cli_cmd() -> Command {
-    Command::new(assert_cmd::cargo::cargo_bin!("toonify-cli"))
+    Command::new(assert_cmd::cargo::cargo_bin!("toonify"))
 }
 
 #[test]


### PR DESCRIPTION
This pull request introduces a major version upgrade and a significant rebranding for the CLI, along with new features for estimating LLM token savings. The CLI crate is renamed from `toonify-cli` to `toonifytool-cli`, and the binary is now called `toonify`. The workspace, documentation, and Docker setup are updated to reflect these changes. Additionally, a new token savings estimation feature is added to the CLI, powered by the `tiktoken-rs` library, allowing users to compare token counts for different models (e.g., `cl100k_base`, `o200k_base`). The author information is also updated across all crates.

### CLI rebranding and workspace updates

* Renamed CLI crate from `toonify-cli` to `toonifytool-cli`, updated the binary name to `toonify`, and changed all references in the workspace, Dockerfile, and documentation to match the new naming convention. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R23) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R10) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R89) [[5]](diffhunk://#diff-a5b2a3093d4a4cb576b24279cd92184824775f81098cdc97503befcb39386504L2-R17) [[6]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aL2-R10) [[7]](diffhunk://#diff-ab766209636372eba853c4822441d1f7c55b89123f97384f13355d9c6a8f1eb6L11-R11)
* Updated author information from "Toonify Contributors" to "Andrea Iannoli" and bumped the version to `1.0.0` in all crate manifests. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R23) [[2]](diffhunk://#diff-98ff543d5073f14c4dfb7b62ef82cdb26bcac28480e95767c54d4176807a6464L3-R5) [[3]](diffhunk://#diff-4828eff974e2292d67f267637f1a0d57cb8c599b08b518af3066f98eca15be75L3-R5) [[4]](diffhunk://#diff-bbd5d27079d30a5164f14fd1698b5557db4355298f1d6bafec4aaec5e2b8be2bL3-R5) [[5]](diffhunk://#diff-a5b2a3093d4a4cb576b24279cd92184824775f81098cdc97503befcb39386504L2-R17)

### Token savings estimation feature

* Added a new feature to the CLI: the `--token-report` flag, which prints a report comparing token counts between the input and TOON output, using the selected token model (`cl100k_base` or `o200k_base`). [[1]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aR74-R81) [[2]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aR108-R110) [[3]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aR163-R183) [[4]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aR254-R277) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R89) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-R157)
* Integrated the `tiktoken-rs` library and implemented token counting logic in the new `tokens.rs` module in `toonify-core`. [[1]](diffhunk://#diff-bbd5d27079d30a5164f14fd1698b5557db4355298f1d6bafec4aaec5e2b8be2bR22-R23) [[2]](diffhunk://#diff-600451553f0dec453f26dade9f2bbbabb7b569b35f0f0826f0ac6a475dbb2342R7) [[3]](diffhunk://#diff-600451553f0dec453f26dade9f2bbbabb7b569b35f0f0826f0ac6a475dbb2342R17) [[4]](diffhunk://#diff-701f97c60811436c7358a676488d698f88297082b710763474a8f8a8bcac7248R1-R52)
* Improved error handling in `toonify-core` to support tokenizer errors. [[1]](diffhunk://#diff-50e599ec1cf55f229b363119d42f095394ba39badc4243935ba511d609300ceeR27-R28) [[2]](diffhunk://#diff-50e599ec1cf55f229b363119d42f095394ba39badc4243935ba511d609300ceeR49-R52)

### Documentation and test updates

* Updated the `README.md` to reflect the new CLI name, usage examples, installation instructions, and the new token report feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-R157)
* Adjusted CLI tests and code to use the new binary name `toonify`.

### Dependency and code maintenance

* Added new workspace dependencies: `once_cell` and `tiktoken-rs`, and propagated them to relevant crates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R23) [[2]](diffhunk://#diff-bbd5d27079d30a5164f14fd1698b5557db4355298f1d6bafec4aaec5e2b8be2bR22-R23)
* Minor code cleanups and ordering improvements in Rust source files. [[1]](diffhunk://#diff-57af18dbd0070e35a14e183a52ece76c980f7c45f3dd3835cfacfcc0669a9884R1-R7) [[2]](diffhunk://#diff-280ed7c96fb52741ef27350091169ff2461338187ea822567859f86964ada47aL2-R10)

These changes collectively modernize the project, improve usability, and introduce valuable new functionality for users interested in LLM token efficiency.

Closes #1 